### PR TITLE
Add GitHub workflow to check script invocations.

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,0 +1,37 @@
+# This workflow runs scripts.
+#
+# You can adjust the behavior by modifying this file.
+name: Run scripts with --help
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  scripts:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        python-version:
+          - "3.7"  # EOL 2023-06-27
+          - "3.8"  # EOL 2024-10
+          - "3.9"  # EOL 2025-10
+          - "3.10"  # EOL 2026-10
+          - "3.11"  # EOL 2027-10
+        experimental: [false]
+        include:
+          - python-version: 3.x
+            experimental: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: install poetry
+        run: pipx install poetry
+      - name: setup python-${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: poetry
+      - name: initiliase --help
+        run: poetry run -- initialise --help


### PR DESCRIPTION
Ensure that the scripts we export from the project at least can run with their
help argument.  This catches top-level invocation errors that would otherwise
make bug reporting even harder.