### PR TITLE
Add python-version 3.10 specifier to publish workflow.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: poetry
+          python-version: "3.10"
       - name: poetry build
         run: poetry build
       - name: poetry publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ license = "unlicense"
 name = "templatise"
 readme = "README.md"
 repository = "https://github.com/alunduil/template.py"
-version = "1.0.1"
+version = "1.0.2"
 
 [tool.poetry.dependencies]
 beautifulsoup4 = "^4.11.1"


### PR DESCRIPTION
As requested in
https://github.com/actions/setup-python/issues/633#issuecomment-1484807496, I'm
adding the python version specifier in this workflow.  Hopefully this will
resolve or otherwise change this workflows result.