### PR TITLE
Bump version 1.0.3 to 1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ license = "unlicense"
 name = "templatise"
 readme = "README.md"
 repository = "https://github.com/alunduil/template.py"
-version = "1.0.3"
+version = "1.1.2"
 
 [tool.poetry.dependencies]
 beautifulsoup4 = "^4.11.1"


### PR DESCRIPTION
This is to reify versions between pyproject and GitHub which should bring pypi
up to date as well.